### PR TITLE
Add script for undoing deployed assignments

### DIFF
--- a/undo_deployment.py
+++ b/undo_deployment.py
@@ -1,0 +1,36 @@
+import getpass
+from openreview.api import OpenReviewClient
+
+username = input("Enter your username: ")
+password = getpass.getpass("Enter your password: ")
+
+BASE_API_URL = "https://api2.openreview.net"
+
+client = OpenReviewClient(
+    baseurl=BASE_API_URL,
+    username=username,
+    password=password
+)
+
+# How to Undo Deployed Assignments
+# See: https://docs.openreview.net/how-to-guides/paper-matching-and-assignment/how-to-undo-deployed-assignments
+domain = 'chilconference.org/CHIL/2024/Conference'
+notes = client.get_notes(invitation=f'{domain}/Senior_Area_Chairs/-/Assignment_Configuration')
+
+# for reviewers
+# notes = client.get_notes(invitation=f'{domain}/Reviewers/-/Assignment_Configuration')
+
+for note in notes:
+    if note.content['status']['value'] == 'Deployed':
+        configuration_note = note
+        break
+
+client.post_note_edit(invitation=f'{domain}/-/Edit',
+signatures=['~Tom_Pollard1'],
+note=openreview.api.Note(
+  id=configuration_note.id,
+  content={
+     'status': { 'value': 'Complete' }
+  }
+))
+print('The deployment has been undone.')


### PR DESCRIPTION
This is a quick pull request to add a script for undoing deployed assignments. The script can be used for undoing papers that are assigned to Area Chairs or Reviewers (using API v2).

This repository needs thought on how it is organized. For now, I'm just dropping the script that I used into the repo in case it is useful in future.